### PR TITLE
Fix potential minor issue with workflow; add badge to README

### DIFF
--- a/.github/workflows/crowdin.yml
+++ b/.github/workflows/crowdin.yml
@@ -103,8 +103,7 @@ jobs:
           git config user.name github-actions
           git config user.email github-actions@github.com
           git add .
-          git commit -m "Update translation progress"
-          git push
+          git commit -m "Update translation progress" && git push || true
 
   create_release:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # April Fools' Translation Pack
+
 [![Modrinth](https://img.shields.io/modrinth/dt/april-fools-translation?label=Modrinth&color=darkgreen&labelColor=black&logo=modrinth)](https://modrinth.com/mod/april-fools-translation)
+[![Crowdin](https://badges.crowdin.net/mcaf-resourcepack/localized.svg)](https://crowdin.com/project/mcaf-resourcepack)
 
 [Deutsch](README.de.md) | English | [日本語](README.ja.md) | [简体中文](README.zh-hans.md) | [繁體中文](README.zh-hant.md)
 


### PR DESCRIPTION
Two changes:
- Ensure that the `update_progress` workflow step always succeeds, even if there's no updates to commit.
  - This way, even if the progress percentages don't change but there's still minor changes, a new release is still created.
- Also add the Crowdin badge to the main README, forgot to add it there; it was just in the translated versions.